### PR TITLE
fix(zoom-resolution): calculation instead of lookup

### DIFF
--- a/src/common/config/index.ts
+++ b/src/common/config/index.ts
@@ -35,32 +35,7 @@ const EXPORTER_CONFIG = {
   MAP: {
     CENTER: MAP.center as [number, number],
     ZOOM: MAP.zoom as number,
-    LOOKUPS: {
-      LEVEL_RESOLUTION: [
-        { zoom: 0, pixel_size_meters: 78271.52 },
-        { zoom: 1, pixel_size_meters: 39135.76 },
-        { zoom: 2, pixel_size_meters: 19567.88 },
-        { zoom: 3, pixel_size_meters: 9783.94 },
-        { zoom: 4, pixel_size_meters: 4891.97 },
-        { zoom: 5, pixel_size_meters: 2445.98 },
-        { zoom: 6, pixel_size_meters: 1222.99 },
-        { zoom: 7, pixel_size_meters: 611.5 },
-        { zoom: 8, pixel_size_meters: 305.75 },
-        { zoom: 9, pixel_size_meters: 152.87 },
-        { zoom: 10, pixel_size_meters: 76.44 },
-        { zoom: 11, pixel_size_meters: 38.22 },
-        { zoom: 12, pixel_size_meters: 19.11 },
-        { zoom: 13, pixel_size_meters: 9.55 },
-        { zoom: 14, pixel_size_meters: 4.78 },
-        { zoom: 15, pixel_size_meters: 2.39 },
-        { zoom: 16, pixel_size_meters: 1.19 },
-        { zoom: 17, pixel_size_meters: 0.6 },
-        { zoom: 18, pixel_size_meters: 0.3 },
-        { zoom: 19, pixel_size_meters: 0.15 },
-        { zoom: 20, pixel_size_meters: 0.075 },
-        { zoom: 21, pixel_size_meters: 0.037 },
-      ],
-    },
+    ZERO_ZOOM_LEVEL_RESOLUTION: 78271.52, // pixel_size_meters
   },
   ACTIVE_LAYER: ACTIVE_LAYER, // | 'WMTS_LAYER' | 'WMS_LAYER' | 'XYZ_LAYER' | 'OSM_DEFAULT'
   ACTIVE_LAYER_PROPERTIES: ACTIVE_LAYER_PROPERTIES,

--- a/src/common/helpers/zoom-resolution.ts
+++ b/src/common/helpers/zoom-resolution.ts
@@ -1,9 +1,20 @@
 import EXPORTER_CONFIG from '../../common/config';
 
-const getResolutionInMeteres = (zoomLevel: number): number | string => {
-  const zoom = EXPORTER_CONFIG.MAP.LOOKUPS.LEVEL_RESOLUTION.find(zoomObject => zoomObject.zoom === zoomLevel);
+// const prettyFloat = (value: number, precision: number=0, localize: boolean=false): string => {
+//   const rounded = (!isNaN(precision) && parseInt(precision.toString(), 10) > 0)
+//       ? parseFloat(value.toString()).toFixed(parseInt(precision.toString(), 10))
+//       : value;
+//   const trimmed = parseFloat(rounded.toString()).toString();
+//   if (localize) {
+//       return parseFloat(trimmed).toLocaleString();
+//   }
+//   return trimmed;
+// };
 
-  return zoom?.pixel_size_meters ?? 'UNMAPPED';
+const getResolutionInMeteres = (zoomLevel: number): number | string => {
+  // prettyFloat() might be used to trim trailing zeros
+  // eslint-disable-next-line
+  return (EXPORTER_CONFIG.MAP.ZERO_ZOOM_LEVEL_RESOLUTION / Math.pow(2, zoomLevel)).toFixed(3);
 };
 
 export { getResolutionInMeteres };


### PR DESCRIPTION
Calculation instead of config lookup values.
Precision of result is 3 digits after the dot